### PR TITLE
Auth improvements

### DIFF
--- a/src/drive/browser.ts
+++ b/src/drive/browser.ts
@@ -26,7 +26,7 @@ import {
 } from '@jupyterlab/filebrowser';
 
 import {
-  driveReady, authorize, DEFAULT_CLIENT_ID
+  driveReady, signIn, DEFAULT_CLIENT_ID
 } from '../gapi';
 
 
@@ -140,7 +140,7 @@ class GoogleDriveLogin extends Widget {
     settingsPromise.then( settings => {
       let cached = settings.get('clientId') as string || null;
       this._clientId = cached === null ? DEFAULT_CLIENT_ID : cached;
-      authorize(this._clientId, false).then(success => {
+      signIn(this._clientId).then(success => {
         if (!success) {
           this._button.style.visibility = 'visible';
         }
@@ -153,7 +153,7 @@ class GoogleDriveLogin extends Widget {
   }
 
   private _onLoginClicked(): void {
-    authorize(this._clientId, true);
+    signIn(this._clientId);
   }
 
   private _button: HTMLElement = null;

--- a/src/drive/browser.ts
+++ b/src/drive/browser.ts
@@ -30,7 +30,8 @@ import {
 } from '@jupyterlab/filebrowser';
 
 import {
-  gapiAuthorized, initializeGapi, signIn, signOut
+  gapiAuthorized, initializeGapi,
+  signIn, signOut, getCurrentUserProfile
 } from '../gapi';
 
 
@@ -51,9 +52,14 @@ const GOOGLE_DRIVE_FILEBROWSER_CLASS = 'jp-GoogleDriveFileBrowser';
 const LOGIN_SCREEN = 'jp-GoogleLoginScreen';
 
 /**
- * Class for a logout button.
+ * Class for a user badge UI button.
  */
-const SHARE_BUTTON = 'jp-UserIcon';
+const USER_BADGE = 'jp-GoogleUserBadge';
+
+/**
+ * Class for a container for the user badge.
+ */
+const USER_BADGE_CONTAINER = 'jp-GoogleUserBadge-container';
 
 /**
  * Widget for hosting the Google Drive filebrowser.
@@ -115,13 +121,21 @@ class GoogleDriveFileBrowser extends Widget {
                                       this._manager, this._factory,
                                       this._driveName);
     // Create the logout button.
+    let userProfile = getCurrentUserProfile();
+    let initial = userProfile.getGivenName()[0];
     let logout = new ToolbarButton({
-      className: SHARE_BUTTON,
       onClick: () => {
         this._onLogoutClicked();
       },
-      tooltip: 'Sign out'
+      tooltip: userProfile.getEmail()
     });
+    let badgeContainer = document.createElement('div');
+    badgeContainer.className = USER_BADGE_CONTAINER;
+    let badge = document.createElement('div');
+    badge.className = USER_BADGE;
+    badge.textContent = initial;
+    badgeContainer.appendChild(badge);
+    logout.node.appendChild(badgeContainer);
 
     this._browser.toolbar.addItem('logout', logout);
     this._loginScreen.parent = null;

--- a/src/drive/browser.ts
+++ b/src/drive/browser.ts
@@ -26,7 +26,7 @@ import {
 } from '@jupyterlab/filebrowser';
 
 import {
-  driveReady, signIn, DEFAULT_CLIENT_ID
+  gapiAuthorized, initializeGapi, signIn
 } from '../gapi';
 
 
@@ -73,7 +73,7 @@ class GoogleDriveFileBrowser extends Widget {
 
     // After authorization and we are ready to use the
     // drive, swap out the widgets.
-    driveReady.then(() => {
+    gapiAuthorized.promise.then(() => {
       this._browser = createFileBrowser(this._registry, this._commands,
                                         this._manager, this._factory,
                                         this._driveName);
@@ -138,10 +138,9 @@ class GoogleDriveLogin extends Widget {
     // a Google account, this will likely succeed. Otherwise, they
     // will need to login explicitly.
     settingsPromise.then( settings => {
-      let cached = settings.get('clientId') as string || null;
-      this._clientId = cached === null ? DEFAULT_CLIENT_ID : cached;
-      signIn(this._clientId).then(success => {
-        if (!success) {
+      this._clientId = settings.get('clientId') as string || null;
+      initializeGapi(this._clientId).then(loggedIn => {
+        if (!loggedIn) {
           this._button.style.visibility = 'visible';
         }
       });
@@ -153,11 +152,11 @@ class GoogleDriveLogin extends Widget {
   }
 
   private _onLoginClicked(): void {
-    signIn(this._clientId);
+    signIn();
   }
 
   private _button: HTMLElement = null;
-  private _clientId: string = DEFAULT_CLIENT_ID;
+  private _clientId: string;
 }
 
 

--- a/src/gapi.ts
+++ b/src/gapi.ts
@@ -232,6 +232,20 @@ function signIn(): Promise<boolean> {
 }
 
 /**
+ * Sign a user out of their Google account.
+ *
+ * @returns a promise resolved when sign-out is complete.
+ */
+export
+function signOut(): Promise<void> {
+  let googleAuth = gapi.auth2.getAuthInstance();
+  // Invalidate the gapiAuthorized promise and set up a new one.
+  gapiAuthorized = null;
+  gapiAuthorized = new PromiseDelegate<void>();
+  return googleAuth.signOut();
+}
+
+/**
  * Refresh the authorization token for Google APIs.
  *
  * #### Notes

--- a/src/gapi.ts
+++ b/src/gapi.ts
@@ -286,7 +286,6 @@ function refreshAuthToken(): Promise<void> {
   });
 }
 
-
 /**
  * Wrap an API error in a hacked-together error object
  * masquerading as an `IAJaxError`.

--- a/src/gapi.ts
+++ b/src/gapi.ts
@@ -214,7 +214,7 @@ function signIn(): Promise<boolean> {
     gapiInitialized.promise.then(() => {
       let googleAuth = gapi.auth2.getAuthInstance();
       if (!googleAuth.isSignedIn.get()) {
-        googleAuth.signIn().then((result: any) => {
+        googleAuth.signIn({ prompt: 'select_account' }).then(() => {
           refreshAuthToken().then(() => {
             // Resolve the exported promise.
             gapiAuthorized.resolve(void 0);

--- a/src/gapi.ts
+++ b/src/gapi.ts
@@ -14,7 +14,6 @@ import {
 
 // TODO: Complete gapi typings and commit upstream.
 declare let gapi: any;
-declare let google: any;
 
 /**
  * Default Client ID to let the Google Servers know who
@@ -37,59 +36,94 @@ const FORBIDDEN_ERROR = 403;
 const RATE_LIMIT_REASON = 'rateLimitExceeded';
 
 /**
- * A handle to the singleton GoogleAuth instance.
+ * A promise delegate that is resolved when the google client
+ * libraries are loaded onto the page.
  */
-let googleAuth: any = null;
+export
+let gapiLoaded = new PromiseDelegate<void>();
 
 /**
- * A promise that is resolved when the user authorizes
+ * A promise delegate that is resolved when the gapi client
+ * libraries are initialized.
+ */
+export
+let gapiInitialized = new PromiseDelegate<void>();
+
+/**
+ * A promise delegate that is resolved when the user authorizes
  * the app to access their Drive account.
  */
 export
 let gapiAuthorized = new PromiseDelegate<void>();
 
 /**
- * A promise that resolves when Google Drive is ready.
+ * Load the gapi scripts onto the page.
+ *
+ * @returns a promise that resolves when the gapi scripts are loaded.
  */
 export
-let driveReady = gapiAuthorized.promise;
+function loadGapi(): Promise<void> {
+  return new Promise<void>( (resolve, reject) => {
+    // Get the gapi script from Google.
+    $.getScript('https://apis.google.com/js/api.js')
+    .done((script, textStatus) => {
+      // Load overall API.
+      (window as any).gapi.load('client:auth2,drive-realtime,drive-share', () => {
+        // Load the specific client libraries we need.
+        console.log("gapi: loaded onto page");
+        gapiLoaded.resolve(void 0);
+        resolve(void 0);
+      });
+    }).fail( () => {
+      console.log("gapi: unable to load onto page");
+      gapiLoaded.reject(void 0);
+      reject(void 0);
+    });
+  });
+}
 
 /**
- * A Promise that loads the gapi scripts onto the page,
- * and resolves when it is done.
+ * Initialize the gapi client libraries.
+ *
+ * @param clientId: The client ID for the project from the
+ *   Google Developer Console. If not given, defaults to
+ *   a testing project client ID. However, if you are deploying
+ *   your own Jupyter server, or are making heavy use of the
+ *   API, it is probably a good idea to set up your own client ID.
+ *
+ * @returns a promise that resolves when the client libraries are loaded.
+ *   The return value of the promise is a boolean indicating whether
+ *   the user was automatically signed in by the initialization.
  */
 export
-let gapiLoaded = new Promise<void>( (resolve, reject) => {
-  // Get the gapi script from Google.
-  $.getScript('https://apis.google.com/js/api.js')
-  .done((script, textStatus) => {
-    // Load overall API.
-    (window as any).gapi.load('client:auth2,drive-realtime,drive-share', () => {
-      // Load client library (for some reason different
-      // from the toplevel API).
-      console.log("gapi: loaded onto page");
+function initializeGapi(clientId: string): Promise<boolean> {
+  return new Promise<boolean>( (resolve, reject) => {
+    gapiLoaded.promise.then(() => {
       gapi.client.init({
         discoveryDocs: DISCOVERY_DOCS,
-        clientId: DEFAULT_CLIENT_ID,
+        clientId: clientId || DEFAULT_CLIENT_ID,
         scope: DRIVE_SCOPE
       }).then(() => {
         // Check if the user is logged in and we are
         // authomatically authorized.
-        googleAuth = gapi.auth2.getAuthInstance();
+        let googleAuth = gapi.auth2.getAuthInstance();
         if (googleAuth.isSignedIn.get()) {
           refreshAuthToken().then(() => {
-            console.log("gapi: authorized.");
             gapiAuthorized.resolve(void 0);
           });
+          gapiInitialized.resolve(void 0);
+          resolve(true);
+        } else {
+          gapiInitialized.resolve(void 0);
+          resolve(false);
         }
-        resolve();
+      }, (err: any) => {
+        gapiInitialized.reject(void 0);
+        reject(void 0);
       });
     });
-  }).fail( () => {
-    console.log("gapi: unable to load onto page");
-    reject();
   });
-});
+}
 
 /**
  * Constants used when attempting exponential backoff.
@@ -118,7 +152,7 @@ function driveApiRequest( request: any, successCode: number = 200, attemptNumber
     return Promise.reject(new Error('Maximum number of API retries reached.'));
   }
   return new Promise<any>((resolve, reject) => {
-    driveReady.then(() => {
+    gapiAuthorized.promise.then(() => {
       request.then( (response: any)=> {
         if(response.status !== successCode) {
           // Handle an HTTP error.
@@ -175,15 +209,17 @@ let authorizeRefresh: any = null;
  *   has been granted.
  */
 export
-function signIn(clientId: string): Promise<boolean> {
+function signIn(): Promise<boolean> {
   return new Promise<boolean>((resolve, reject) => {
-    gapiLoaded.then(() => {
+    gapiInitialized.promise.then(() => {
+      let googleAuth = gapi.auth2.getAuthInstance();
       if (!googleAuth.isSignedIn.get()) {
         googleAuth.signIn().then((result: any) => {
-          refreshAuthToken();
-          // Resolve the exported promise.
-          gapiAuthorized.resolve(void 0);
-          resolve(true);
+          refreshAuthToken().then(() => {
+            // Resolve the exported promise.
+            gapiAuthorized.resolve(void 0);
+            resolve(true);
+          });
         });
       } else {
         // Otherwise we are already signed in.
@@ -206,72 +242,25 @@ function signIn(clientId: string): Promise<boolean> {
  * use the newer, better documented, undeprecated `gapi.auth2`
  * authorization API.
  */
-function refreshAuthToken(): Promise<any> {
+function refreshAuthToken(): Promise<void> {
   return new Promise<any>((resolve, reject) => {
+    let googleAuth = gapi.auth2.getAuthInstance();
     let user = googleAuth.currentUser.get();
     user.reloadAuthResponse().then((authResponse: any) => {
-      gapi.auth.setToken(authResponse, (result: any) => {
-        // Set a timer to refresh the authorization.
-        if(authorizeRefresh) clearTimeout(authorizeRefresh);
-        authorizeRefresh = setTimeout(() => {
-          console.log('gapi: refreshing authorization.')
-          refreshAuthToken();
-        }, 750 * Number(authResponse.expires_in));
-        resolve(result);
-      });
-    });
-  });
-}
-
-/**
- * We do not automatically have permission to access files in a user's 
- * Google Drive which have not been created by this app. If such a file
- * is requested, we need to open a picker dialog to explicitly grant those
- * permissions.
- *
- * @param resource: the files resource that has been requested.
- * 
- * @returns a promise the resolves when the file has been picked.
- */
-export
-function pickFile(resource: any, clientId: string): Promise<void> {
-  let appId = clientId.split('-')[0];
-  return new Promise<any>((resolve,reject) => {
-    let pickerCallback = (response: any) => {
-      // Resolve if the user has picked the selected file.
-      if(response[google.picker.Response.ACTION] ===
-         google.picker.Action.PICKED &&
-         response[google.picker.Response.DOCUMENTS][0][google.picker.Document.ID] ===
-         resource.id) {
-        resolve(void 0);
-      } else if(response[google.picker.Response.ACTION] ===
-         google.picker.Action.PICKED &&
-         response[google.picker.Response.DOCUMENTS][0][google.picker.Document.ID] !==
-         resource.id) {
-        reject(new Error('Wrong file selected for permissions'));
-      } else if(response[google.picker.Response.ACTION] ===
-         google.picker.Action.CANCEL) {
-        reject(new Error('Insufficient permisson to open file'));
+      gapi.auth.setToken(authResponse);
+      // Set a timer to refresh the authorization.
+      if(authorizeRefresh) {
+        clearTimeout(authorizeRefresh);
       }
-    }
-    driveReady.then(() => {
-      let pickerView = new google.picker.DocsView(google.picker.ViewId.DOCS)
-          .setMode(google.picker.DocsViewMode.LIST)
-          .setParent(resource.parents[0])
-          .setQuery(resource.name);
-
-      let picker = new google.picker.PickerBuilder()
-        .addView(pickerView)
-        .enableFeature(google.picker.Feature.NAV_HIDDEN)
-        .setAppId(appId)
-        .setOAuthToken(gapi.auth.getToken()['access_token'])
-        .setTitle('Select to authorize opening this file with JupyterLab...')
-        .setCallback(pickerCallback)
-        .build();
-      picker.setVisible(true);
+      authorizeRefresh = setTimeout(() => {
+        console.log('gapi: refreshing authorization.')
+        refreshAuthToken();
+      }, 750 * Number(authResponse.expires_in));
+      resolve(void 0);
     });
   });
 }
+
 
 /**
  * Wrap an API error in a hacked-together error object

--- a/src/gapi.ts
+++ b/src/gapi.ts
@@ -246,6 +246,17 @@ function signOut(): Promise<void> {
 }
 
 /**
+ * Get the basic profile of the currently signed-in user.
+ *
+ * @returns a `gapi.auth2.BasicProfile instance.
+ */
+export
+function getCurrentUserProfile(): any {
+  let user = gapi.auth2.getAuthInstance().currentUser.get();
+  return user.getBasicProfile();
+}
+
+/**
  * Refresh the authorization token for Google APIs.
  *
  * #### Notes

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,10 @@ import {
   GoogleDrive
 } from './drive/contents';
 
+import {
+  loadGapi
+} from './gapi';
+
 const fileBrowserPlugin: JupyterLabPlugin<void> = {
   id: 'jupyter.extensions.google-drive',
   requires: [ICommandPalette, IDocumentManager, IDocumentRegistry, IFileBrowserFactory, ILayoutRestorer, ISettingRegistry],
@@ -52,6 +56,9 @@ const fileBrowserPlugin: JupyterLabPlugin<void> = {
 function activateFileBrowser(app: JupyterLab, palette: ICommandPalette, manager: IDocumentManager, registry: IDocumentRegistry, factory: IFileBrowserFactory, restorer: ILayoutRestorer, settingRegistry: ISettingRegistry): void {
   let { commands } = app;
   const id = fileBrowserPlugin.id;
+
+  // Load the gapi libraries onto the page.
+  loadGapi();
 
   // Add the Google Drive backend to the contents manager.
   let drive = new GoogleDrive(registry);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,10 @@
 import '../style/index.css';
 
 import {
+  Widget
+} from '@phosphor/widgets';
+
+import {
   JupyterLab, JupyterLabPlugin
 } from '@jupyterlab/application';
 
@@ -72,9 +76,24 @@ function activateFileBrowser(app: JupyterLab, palette: ICommandPalette, manager:
   });
   settingRegistry.annotate(id, 'clientId', { label: 'Client ID' });
 
+  // Construct a function that determines whether any documents
+  // associated with this filebrowser are currently open.
+  let hasOpenDocuments = () => {
+    let iterator = app.shell.widgets('main');
+    let widget: Widget;
+    while (widget = iterator.next()) {
+      let context = manager.contextForWidget(widget);
+      if (context && context.path.split(':')[0] === drive.name) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   // Create the file browser.
   let browser = new GoogleDriveFileBrowser(
-    registry, commands, manager, factory, drive.name, settingRegistry.load(id));
+    drive.name, registry, commands, manager, factory,
+    settingRegistry.load(id), hasOpenDocuments);
 
   // Add the file browser widget to the application restorer.
   restorer.add(browser, NAMESPACE);

--- a/src/realtime/modeldb.ts
+++ b/src/realtime/modeldb.ts
@@ -417,13 +417,17 @@ class GoogleModelDB implements IModelDB {
     if (this.isDisposed) {
       return;
     }
-    let db = this._db;
-    this._db = null;
+    let doc = this._doc;
+    this._doc = null;
+    doc.removeAllEventListeners();
+    doc.close();
     this._doc = null;
     this._model = null;
+    this._baseDB = null;
 
-    if (db) {
-      db.dispose();
+    if (this._db) {
+      this._db.dispose();
+      this._db = null;
     }
     this._disposables.dispose();
   }

--- a/style/index.css
+++ b/style/index.css
@@ -47,7 +47,3 @@
 .jp-ShareIcon {
   background-image: url(share.svg);
 }
-
-.jp-UserIcon {
-  background-image: url(user.svg);
-}

--- a/style/index.css
+++ b/style/index.css
@@ -29,6 +29,21 @@
   background-image: url(drive.png);
 }
 
+.jp-GoogleUserBadge-container {
+  display: flex;
+  justify-content: center;
+}
+
+.jp-GoogleUserBadge {
+  background-color: #F37626;
+  color: white;
+  border-radius: 50%;
+  height: 18px;
+  width: 18px;
+  line-height: 18px;
+}
+
+
 .jp-ShareIcon {
   background-image: url(share.svg);
 }

--- a/style/index.css
+++ b/style/index.css
@@ -32,3 +32,7 @@
 .jp-ShareIcon {
   background-image: url(share.svg);
 }
+
+.jp-UserIcon {
+  background-image: url(user.svg);
+}

--- a/style/user.svg
+++ b/style/user.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/style/user.svg
+++ b/style/user.svg
@@ -1,4 +1,0 @@
-<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-    <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/>
-    <path d="M0 0h24v24H0z" fill="none"/>
-</svg>


### PR DESCRIPTION
Makes a number of improvements with regards to authorization, logging in, etc.

1. Updates to use the undeprecated `gapi.auth2` API for authentication. There is a bit of an ugly workaround involving `gapi.auth.setToken()` related to a bug in the realtime API (tracked in google/google-api-javascript-client#287). Hopefully that will be simpler in the future.
2. Better split for the loading of the Google client scripts, their initialization, and user authorization, so they can be done as early as possible but no earlier. Each of these steps exports a `PromiseDelegate`.
3. Allowing for signing in and out of multiple Google accounts within the same JupyterLab session.
4. Removal of Google Picker, which is not necessary at the currently requested permission scopes.