### PR TITLE
Use Google Drive logo for tabbar icon.

### DIFF
--- a/src/drive/browser.ts
+++ b/src/drive/browser.ts
@@ -94,7 +94,7 @@ class GoogleDriveFileBrowser extends Widget {
       this._createBrowser();
     });
 
-    this.title.label = 'Google Drive';
+    this.title.iconClass = 'jp-GoogleDrive-tablogo';
     this.id = 'google-drive-file-browser';
   }
 
@@ -193,8 +193,14 @@ class GoogleDriveLogin extends Widget {
 
     // Add the logo.
     let logo = document.createElement('div');
-    logo.className = 'jp-GoogleDriveLogo';
+    logo.className = 'jp-GoogleDrive-logo';
     this.node.appendChild(logo);
+
+    // Add the text.
+    let text = document.createElement('div');
+    text.className = 'jp-GoogleDrive-text';
+    text.textContent = 'Google Drive';
+    this.node.appendChild(text);
 
     // Add the login button.
     this._button = document.createElement('button');

--- a/style/index.css
+++ b/style/index.css
@@ -22,10 +22,23 @@
   align-items: center;
 }
 
-.jp-GoogleDriveLogo {
+.jp-GoogleDrive-logo {
   background-size: 100%;
   width: 150px;
   height: 150px;
+  background-image: url(drive.png);
+}
+
+.jp-GoogleDrive-text {
+  font-size: var(--jp-ui-font-size3);
+  padding: 12px;
+}
+
+
+.jp-GoogleDrive-tablogo {
+  background-size: 100%;
+  width: var(--jp-private-sidebar-tab-width);
+  height: var(--jp-private-sidebar-tab-width);
   background-image: url(drive.png);
 }
 
@@ -42,7 +55,6 @@
   width: 18px;
   line-height: 18px;
 }
-
 
 .jp-ShareIcon {
   background-image: url(share.svg);


### PR DESCRIPTION
Addresses some feedback from the 6/16 meeting.
This adds the Google Drive logo to the tabbar instead of using the name, which adds some color and takes up less space.
![tablogo](https://user-images.githubusercontent.com/5728311/27302230-0e6013c8-54eb-11e7-9723-e69ef85f1553.png)
