### PR TITLE
Add more useful error upon gapi initialization failure.

### DIFF
--- a/src/drive/browser.ts
+++ b/src/drive/browser.ts
@@ -231,6 +231,12 @@ class GoogleDriveLogin extends Widget {
             this._button.style.visibility = 'visible';
           });
         }
+      }).catch( (err: any) => {
+        showDialog({
+          title: 'Google API Error',
+          body: err,
+          buttons: [Dialog.okButton({label: 'OK'})]
+        });
       });
     });
   }

--- a/src/gapi.ts
+++ b/src/gapi.ts
@@ -115,8 +115,9 @@ function initializeGapi(clientId: string): Promise<boolean> {
           resolve(false);
         }
       }, (err: any) => {
-        gapiInitialized.reject(void 0);
-        reject(void 0);
+        gapiInitialized.reject(err);
+        // A useful error message is in err.details.
+        reject(err.details);
       });
     });
   });


### PR DESCRIPTION
It has come up more than once that a user tries to set their own client ID and the Google servers reject it for due to an incorrect origin. This is somewhat documented in [advanced.md](advanced.md), but the UI did not provide a very useful error message (cf #37, #7). This passes on the error message to a dialog.