### PR TITLE
use basename of path if contents.name is undefined

### DIFF
--- a/src/drive/drive.ts
+++ b/src/drive/drive.ts
@@ -959,7 +959,7 @@ function fileResourceFromContentsModel(contents: Partial<Contents.IModel>, fileT
       break;
   }
   return {
-    name: contents.name,
+    name: contents.name || PathExt.basename(contents.path),
     mimeType
   };
 }


### PR DESCRIPTION
This fixes part of #52. New file can be saved to Google Drive with new name.