### PR TITLE
Resolve nosessionbound

### DIFF
--- a/src/drive/drive.ts
+++ b/src/drive/drive.ts
@@ -20,7 +20,8 @@ import {
 } from '@jupyterlab/docregistry';
 
 import {
-  driveApiRequest, gapiAuthorized, gapiInitialized, makeError
+  driveApiRequest, gapiAuthorized, gapiInitialized,
+  handleRealtimeError, makeError
 } from '../gapi';
 
 
@@ -526,10 +527,7 @@ function loadRealtimeDocument(resource: FileResource, picked: boolean = false): 
         resolve(doc);
       }, (model: gapi.drive.realtime.Model) => {
         /* no-op initializer */
-      }, (err: any) => {
-        // If there is a not found error, we may need to invoke
-        // the picker to gain file access.
-      });
+      }, handleRealtimeError);
     });
   });
 }

--- a/src/gapi.ts
+++ b/src/gapi.ts
@@ -288,6 +288,30 @@ function makeError(code: number, message: string): ServerConnection.IError {
   } as any as ServerConnection.IError;
 }
 
+/**
+ * Handle an error thrown by a realtime file,
+ * if possible.
+ *
+ * @param err - the realtime error.
+ */
+export
+function handleRealtimeError(err: gapi.drive.realtime.Error): void {
+  if (err.type === gapi.drive.realtime.ErrorType.TOKEN_REFRESH_REQUIRED) {
+    // gapi.auth2 automatically refreshes the token,
+    // but due to a bug in the drive realtime client,
+    // this is not automatically picked up by the
+    // realtime system. If we get a TOKEN_REFRESH_REQUIRED,
+    // it should be enough to manually set the token that
+    // has already been refreshed.
+    Private.setAuthToken();
+  } else if (err.isFatal === false) {
+    // If we can recover, do nothing.
+    return void 0;
+  } else {
+   throw err;
+  }
+}
+
 
 /**
  * A namespace for private functions and values.

--- a/src/gapi.ts
+++ b/src/gapi.ts
@@ -201,6 +201,9 @@ function driveApiRequest<T>( createRequest: () => gapi.client.HttpRequest<T>, su
             .then(result => {
               resolve(result);
             });
+          }).catch(err => {
+            let result: any = response.result;
+            reject(makeError(result.error.code, result.error.message));
           });
         } else {
           let result: any = response.result;
@@ -320,11 +323,15 @@ namespace Private {
    */
   export
   function refreshAuthToken(): Promise<void> {
-    return new Promise<void>(resolve => {
+    return new Promise<void>((resolve, reject) => {
       const googleAuth = gapi.auth2.getAuthInstance();
       const user = googleAuth.currentUser.get();
       user.reloadAuthResponse().then(authResponse => {
         setAuthToken();
+      }, err => {
+        console.error('Error on refreshing authorization!');
+        setAuthToken();
+        reject(err);
       });
     });
   }


### PR DESCRIPTION
Possible fix for #93 and #94.

When serving over port 80, the Google Client library fails for somewhat opaque reasons when calling `user.reloadAuthRespose()`, which we use to manually refresh authorization when we get credential errors from Google. This does not happen when serving over other ports. See more discussion in google/google-api-javascript-client#349.

In theory, `gapi.auth2` refreshes the authorization on its own, so we should not need to manually call `reloadAuthResponse()`. However, the realtime library has a separate bug that prevents it from picking up that token response. For that reason, we have been manually refreshing and resetting the token.

This changes the strategy to do
1. Don't call `user.reloadAuthResponse()`, unless we actually catch errors that indicate credentials are wrong.
2. If we do call `user.reloadAuthResponse(), try to be somewhat fault tolerant.
3. Instead, we rely upon `gapi.auth2` to correctly refresh its token. When the realtime API hits a token refresh error (as it will), we call `Private.setToken()` to manually pick up the refreshed token.

If the two bugs in the client libraries get fixed, this whole rigmarole will get a lot simpler.