### PR TITLE
There are two hard problems in Computer Science

### DIFF
--- a/src/drive/browser.ts
+++ b/src/drive/browser.ts
@@ -157,19 +157,23 @@ class GoogleDriveFileBrowser extends Widget {
       return;
     }
 
-    // Swap out the file browser for the login screen.
-    this._browser.parent = null;
-    (this.layout as PanelLayout).addWidget(this._loginScreen);
-    this._browser.dispose();
-    this._logoutButton.dispose();
+    // Change to the root directory, so an invalid path
+    // is not cached, then sign out.
+    this._browser.model.cd('/').then(() => {
+      // Swap out the file browser for the login screen.
+      this._browser.parent = null;
+      (this.layout as PanelLayout).addWidget(this._loginScreen);
+      this._browser.dispose();
+      this._logoutButton.dispose();
 
-    // Sign out.
-    signOut().then(() => {
-      // After sign-out, set up a new listener
-      // for authorization, should the user log
-      // back in.
-      gapiAuthorized.promise.then(() => {
-        this._createBrowser();
+      // Do the actual sign-out.
+      signOut().then(() => {
+        // After sign-out, set up a new listener
+        // for authorization, should the user log
+        // back in.
+        gapiAuthorized.promise.then(() => {
+          this._createBrowser();
+        });
       });
     });
   }

--- a/src/drive/drive.ts
+++ b/src/drive/drive.ts
@@ -133,8 +133,6 @@ function uploadFile(path: string, model: Partial<Contents.IModel>, fileType: Doc
   } else {
     resourceReadyPromise = new Promise<FileResource>((resolve, reject) => {
       let enclosingFolderPath = PathExt.dirname(path);
-      enclosingFolderPath =
-        enclosingFolderPath === '.' ? '' : enclosingFolderPath;
       const resource: FileResource = fileResourceFromContentsModel(model, fileType);
       getResourceForPath(enclosingFolderPath)
       .then((parentFolderResource: FileResource) => {
@@ -682,7 +680,6 @@ function moveFile(oldPath: string, newPath: string, fileTypeForPath: (path: stri
     return contentsModelForPath(oldPath, true, fileTypeForPath);
   } else {
     let newFolderPath = PathExt.dirname(newPath);
-    newFolderPath = newFolderPath === '.' ? '' : newFolderPath;
 
     // Get a promise that resolves with the resource in the current position.
     const resourcePromise = getResourceForPath(oldPath)
@@ -760,7 +757,6 @@ function copyFile(oldPath: string, newPath: string, fileTypeForPath: (path: stri
                          ' the same name to the same directory');
   } else {
     let newFolderPath = PathExt.dirname(newPath);
-    newFolderPath = newFolderPath === '.' ? '' : newFolderPath;
 
     // Get a promise that resolves with the resource in the current position.
     const resourcePromise = getResourceForPath(oldPath)
@@ -1288,16 +1284,12 @@ namespace Private {
    */
   export
   function clearCacheForDirectory(path: string): void {
-    // TODO: my TS compiler complains here?
-    const keys = (resourceCache as any).keys();
-    for(let key of keys) {
-      let enclosingFolderPath = PathExt.dirname(path);
-      enclosingFolderPath =
-        enclosingFolderPath === '.' ? '' : enclosingFolderPath;
+    resourceCache.forEach((value, key) => {
+      let enclosingFolderPath = PathExt.dirname(key);
       if(path === enclosingFolderPath) {
         resourceCache.delete(key);
       }
-    }
+    });
   }
 
   /**

--- a/src/drive/drive.ts
+++ b/src/drive/drive.ts
@@ -806,6 +806,22 @@ function copyFile(oldPath: string, newPath: string, fileTypeForPath: (path: stri
   }
 }
 
+/**
+ * Invalidate the resource cache.
+ *
+ * #### Notes
+ * The resource cache is mostly private to this module, and
+ * is essential to not be rate-limited by Google.
+ *
+ * This should only be called when the user signs out, and
+ * the cached information about their directory structure
+ * is no longer valid.
+ */
+export
+function clearCache(): void {
+  Private.resourceCache.clear();
+}
+
 
 /* ******** Functions for dealing with revisions ******** */
 

--- a/src/gapi.ts
+++ b/src/gapi.ts
@@ -9,6 +9,10 @@ import {
   ServerConnection
 } from '@jupyterlab/services';
 
+import {
+  clearCache
+} from './drive/drive';
+
 /**
  * Default Client ID to let the Google Servers know who
  * we are. These can be changed to ones linked to a particular
@@ -265,7 +269,7 @@ function signOut(): Promise<void> {
   const googleAuth = gapi.auth2.getAuthInstance();
   // Invalidate the gapiAuthorized promise and set up a new one.
   gapiAuthorized = new PromiseDelegate<void>();
-  return googleAuth.signOut();
+  return googleAuth.signOut().then(() => { clearCache(); });
 }
 
 /**


### PR DESCRIPTION
Cleans up a couple of cache-related things. As it is, we cache some responses from the Google Drive API, otherwise the users would get rate-limited pretty quickly. This fixes a few of issues related to that:
1. Clear the cache if the user logs out. Then, if they log back in again they are not using an invalid cache.
2. Change directories to the root upon logout. This means that the `cwd` tracked by the `IStateDB` in the file browser is not made incorrect.
3. Fix a bug in clearing the cache on a per-directory basis.