### PR TITLE
Deprecate realtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 ## Realtime collaboration and cloud storage for JupyterLab through Google Drive.
 
+***As of November 28th, 2017, Google has [deprecated](https://developers.google.com/google-apps/realtime/deprecation) their Realtime API.
+Existing realtime applications (such as those you may have set up according to [these](docs/advanced.md) instructions) will still work until December 2018, but new applications will not be able to use the Realtime API.
+See the discussions [here](https://github.com/jupyterlab/jupyterlab-google-drive/issues/108) and [here](docs/advanced.md#Realtime-API) for more information.***
+
 **NOTE: this is alpha software and is rapidly changing.**
 **Files stored on Google Drive using this plugin should still be backed-up elsewhere.**
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -30,7 +30,7 @@ and select `Create` to create a new project.
 6. Under **Authorized Javascript Origins**, provide a list of URLs that will be accessing the APIs (e.g., `http://localhost:8888` or `https://www.myawsesomedeployment.org`).
 ![Web application](images/webapp.png)
 7. The console will now show a **Client ID** field under the **Credentials** panel. This is the ID that will be used in the settings for the `@jupyterlab/google-drive` extension.
-8. In the **API Manager** sidebar, select **Library**. This will provide an interface for enabling different Google APIs for the application. You will need to enable three APIs for the extension to work: **Google Drive API**, **Google Realtime API** and **Google Picker API**.
+8. In the **API Manager** sidebar, select **Library**. This will provide an interface for enabling different Google APIs for the application. You will need to enable two APIs for the extension to work: **Google Drive API** and **Google Picker API** (previously this list included the **Google Realtime API**, which has been [deprecated](https://developers.google.com/google-apps/realtime/deprecation) by Google).
 ![Searching API library](images/library.png)
 The Dashboard panel should now show be showing those APIs:
 ![Dashboard](images/dashboard.png)
@@ -38,6 +38,22 @@ The Dashboard panel should now show be showing those APIs:
 Once these steps have been completed, you will be able to use these credentials in the extension.
 In the `jupyterlab.google-drive` settings of the settings registry, set the **clientID** field to be the client id provided by the developer console. If everything is configured properly, you should be able to use the application with your new credentials.
 ![Client ID](images/clientid.png)
+
+### Realtime API
+On November 28th, 2017, Google [deprecated](https://developers.google.com/google-apps/realtime/deprecation) their realtime API.
+Existing applications that use the realtime API will continue to work until December, 2018.
+If you have already set up a client application using this API, you can set
+```json
+{
+  "realtime": true
+}
+```
+in the JupyterLab settings editor, and
+the plugin will enable realtime editing.
+If you are setting up a *new* client application,
+you should set this value to `false`,
+and realtime editing will not be enabled
+until the core of JupyterLab itself supports it.
 
 ### Seeding JupyterLab images with Google credentials
 While adding credentials via the settings functionality from within JupyterLab is possible, as described above, users may also wish to pre-seed these settings so the extension works out-of-the-box on start-up.
@@ -82,4 +98,4 @@ singleuser
     postStart:
       exec:
         command: ["/bin/sh", "-c", "echo '{\"clientId\":\"${GOOGLE_DRIVE_CLIENT_ID}\"}' > /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.json"]
-``` 
+```

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "mocha": "~3.5.3",
     "rimraf": "~2.6.2",
     "style-loader": "~0.13.2",
-    "typescript": "~2.4.2",
+    "typescript": "~2.6.2",
     "url-loader": "~0.5.9",
     "webpack": "~2.7.0"
   },

--- a/schema/drive.json
+++ b/schema/drive.json
@@ -6,6 +6,9 @@
   "properties": {
     "clientId": {
       "type": "string", "title": "Client ID", "default": ""
+    },
+    "realtime": {
+      "type": "boolean", "title": "Realtime", "default": true
     }
   },
   "type": "object"

--- a/src/chatbox/chatbox.ts
+++ b/src/chatbox/chatbox.ts
@@ -43,8 +43,12 @@ import {
 } from '@jupyterlab/cells';
 
 import {
-  IObservableList, ActivityMonitor
+  ActivityMonitor
 } from '@jupyterlab/coreutils';
+
+import {
+  IObservableList
+} from '@jupyterlab/observables';
 
 import {
   RenderMime

--- a/src/chatbox/entry.ts
+++ b/src/chatbox/entry.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   ICollaborator
-} from '@jupyterlab/coreutils';
+} from '@jupyterlab/observables';
 
 import {
   MarkdownCell

--- a/src/drive/browser.ts
+++ b/src/drive/browser.ts
@@ -82,9 +82,7 @@ class GoogleDriveFileBrowser extends Widget {
 
     // Keep references to the createFileBrowser arguments for
     // when we need to construct it.
-    this._registry = registry;
     this._commands = commands;
-    this._manager = manager;
     this._factory = factory;
     this._driveName = driveName;
 
@@ -182,9 +180,7 @@ class GoogleDriveFileBrowser extends Widget {
   private _browser: FileBrowser;
   private _loginScreen: GoogleDriveLogin;
   private _logoutButton: ToolbarButton;
-  private _registry: DocumentRegistry;
   private _commands: CommandRegistry;
-  private _manager: IDocumentManager;
   private _factory: IFileBrowserFactory;
   private _driveName: string;
   private _hasOpenDocuments: () => boolean;

--- a/src/drive/contents.ts
+++ b/src/drive/contents.ts
@@ -6,12 +6,16 @@ import {
 } from '@phosphor/signaling';
 
 import {
-  PathExt, ModelDB
+  PathExt
 } from '@jupyterlab/coreutils';
 
 import {
   DocumentRegistry
 } from '@jupyterlab/docregistry';
+
+import {
+  ModelDB
+} from '@jupyterlab/observables';
 
 import {
   Contents, ServerConnection,

--- a/src/drive/contents.ts
+++ b/src/drive/contents.ts
@@ -24,7 +24,7 @@ import {
 import * as drive from './drive';
 
 import {
-  makeError
+  makeError, realtimeLoaded
 } from '../gapi';
 
 
@@ -57,18 +57,37 @@ class GoogleDrive implements Contents.IDrive {
     }
   }
 
+  /**
+   * The name of the drive.
+   */
   get name(): 'GDrive' {
     return 'GDrive';
   }
 
+  /**
+   * Getter for the IModelDB factory.
+   */
   get modelDBFactory(): ModelDB.IFactory {
-    return {
-      createNew: (path: string) => {
-        return new GoogleModelDB( {filePath: path} );
+    if (realtimeLoaded) {
+      return {
+        createNew: (path: string) => {
+          return new GoogleModelDB( {filePath: path} );
+        }
+      }
+    } else {
+      return {
+        // If the realtime APIs have not been loaded,
+        // make a new in-memory ModelDB.
+        createNew: (path: string) => {
+          return new ModelDB();
+        }
       }
     }
   }
 
+  /**
+   * Server settings (unused for interfacing with Google Drive).
+   */
   readonly serverSettings: ServerConnection.ISettings;
 
   /**

--- a/src/gapi.ts
+++ b/src/gapi.ts
@@ -60,12 +60,21 @@ export
 let gapiAuthorized = new PromiseDelegate<void>();
 
 /**
+ * A boolean that is set if the deprecated realtime APIs
+ * have been loaded onto the page.
+ */
+export
+let realtimeLoaded = false;
+
+/**
  * Load the gapi scripts onto the page.
+ *
+ * @param realtime - whether to load the (deprecated) realtime libraries.
  *
  * @returns a promise that resolves when the gapi scripts are loaded.
  */
 export
-function loadGapi(): Promise<void> {
+function loadGapi(realtime: boolean): Promise<void> {
   return new Promise<void>( (resolve, reject) => {
     // Get the gapi script from Google.
     const gapiScript = document.createElement('script');
@@ -76,7 +85,11 @@ function loadGapi(): Promise<void> {
     // Load overall API scripts onto the page.
     gapiScript.onload = () => {
       // Load the specific client libraries we need.
-      gapi.load('client:auth2,drive-realtime,drive-share', () => {
+      const libs = realtime ?
+                   'client:auth2,drive-realtime,drive-share' :
+                   'client:auth2';
+      gapi.load(libs, () => {
+        if (realtime) { realtimeLoaded = true };
         gapiLoaded.resolve(void 0);
         resolve(void 0);
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,17 @@ function activateFileBrowser(app: JupyterLab, palette: ICommandPalette, manager:
   const id = fileBrowserPlugin.id;
 
   // Load the gapi libraries onto the page.
-  loadGapi();
+  settingRegistry.load(id).then(settings => {
+    const realtime = settings.get('realtime').composite as boolean;
+    if (realtime === true) {
+      console.warn('Warning: Google Realtime has been deprecated. ' +
+                   'No new realtime applications may be registered, ' +
+                   'and existing ones will cease to work in December 2018');
+      loadGapi(true);
+    } else {
+      loadGapi(false);
+    }
+  });
 
   // Add the Google Drive backend to the contents manager.
   const drive = new GoogleDrive(app.docRegistry);

--- a/src/realtime/collaborator.ts
+++ b/src/realtime/collaborator.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   ICollaborator, IObservableMap
-} from '@jupyterlab/coreutils';
+} from '@jupyterlab/observables';
 
 
 export

--- a/src/realtime/json.ts
+++ b/src/realtime/json.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   IObservableJSON
-} from '@jupyterlab/coreutils';
+} from '@jupyterlab/observables';
 
 import {
   GoogleMap

--- a/src/realtime/list.ts
+++ b/src/realtime/list.ts
@@ -12,7 +12,7 @@ import {
 
 import {
   IObservableList
-} from '@jupyterlab/coreutils';
+} from '@jupyterlab/observables';
 
 import {
   GoogleRealtimeObject, GoogleSynchronizable

--- a/src/realtime/map.ts
+++ b/src/realtime/map.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   IObservableMap
-} from '@jupyterlab/coreutils';
+} from '@jupyterlab/observables';
 
 import {
   GoogleRealtimeObject, GoogleSynchronizable

--- a/src/realtime/modeldb.ts
+++ b/src/realtime/modeldb.ts
@@ -16,7 +16,7 @@ import {
 import {
   IModelDB, IObservableValue, ObservableValue, IObservableString, 
   IObservable, IObservableUndoableList, IObservableJSON
-} from '@jupyterlab/coreutils';
+} from '@jupyterlab/observables';
 
 import {
   CollaboratorMap

--- a/src/realtime/string.ts
+++ b/src/realtime/string.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   IObservableString
-} from '@jupyterlab/coreutils';
+} from '@jupyterlab/observables';
 
 import {
   GoogleRealtimeObject

--- a/src/realtime/undoablelist.ts
+++ b/src/realtime/undoablelist.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   IObservableUndoableList, IObservableList,
-} from '@jupyterlab/coreutils';
+} from '@jupyterlab/observables';
 
 import {
   GoogleList

--- a/test/src/chatbox.spec.ts
+++ b/test/src/chatbox.spec.ts
@@ -29,7 +29,7 @@ import {
 
 import {
   ModelDB, ObservableMap, ObservableList, ICollaborator
-} from '@jupyterlab/coreutils';
+} from '@jupyterlab/observables';
 
 import {
   Chatbox, ChatEntry 

--- a/test/src/collaborator.spec.ts
+++ b/test/src/collaborator.spec.ts
@@ -39,7 +39,7 @@ describe('CollaboratorMap', () => {
   let model: inMemoryModel;
 
   before((done) => {
-    loadGapi().then(() => {
+    loadGapi(true).then(() => {
       initializeGapi(DEFAULT_CLIENT_ID).then(done);
     });
   });

--- a/test/src/collaborator.spec.ts
+++ b/test/src/collaborator.spec.ts
@@ -5,7 +5,7 @@ import expect = require('expect.js');
 
 import {
   ICollaborator
-} from '@jupyterlab/coreutils';
+} from '@jupyterlab/observables';
 
 import {
   CollaboratorMap

--- a/test/src/contents.spec.ts
+++ b/test/src/contents.spec.ts
@@ -60,7 +60,7 @@ describe('GoogleDrive', () => {
 
   before((done) => {
     registry = new DocumentRegistry();
-    loadGapi().then(() => {
+    loadGapi(true).then(() => {
       authorizeGapiTesting().then(() => {
         done();
       }).catch( err => {

--- a/test/src/json.spec.ts
+++ b/test/src/json.spec.ts
@@ -24,7 +24,7 @@ describe('GoogleJSON', () => {
   let json: gapi.drive.realtime.CollaborativeMap<JSONValue>;
 
   before((done) => {
-    loadGapi().then(() => {
+    loadGapi(true).then(() => {
       initializeGapi(DEFAULT_CLIENT_ID).then(done);
     });
   });

--- a/test/src/list.spec.ts
+++ b/test/src/list.spec.ts
@@ -24,7 +24,7 @@ describe('GoogleList', () => {
   let list: gapi.drive.realtime.CollaborativeList<number>;
 
   before((done) => {
-    loadGapi().then(() => {
+    loadGapi(true).then(() => {
       initializeGapi(DEFAULT_CLIENT_ID).then(done);
     });
   });

--- a/test/src/map.spec.ts
+++ b/test/src/map.spec.ts
@@ -21,7 +21,7 @@ describe('GoogleMap', () => {
   let map: gapi.drive.realtime.CollaborativeMap<number>;
 
   before((done) => {
-    loadGapi().then(() => {
+    loadGapi(true).then(() => {
       initializeGapi(DEFAULT_CLIENT_ID).then(done);
     });
   });

--- a/test/src/modeldb.spec.ts
+++ b/test/src/modeldb.spec.ts
@@ -39,7 +39,7 @@ describe('GoogleObservableValue', () => {
   let model: inMemoryModel;
 
   before((done) => {
-    loadGapi().then(() => {
+    loadGapi(true).then(() => {
       initializeGapi(DEFAULT_CLIENT_ID).then(done);
     });
   });

--- a/test/src/string.spec.ts
+++ b/test/src/string.spec.ts
@@ -20,7 +20,7 @@ describe('GoogleString', () => {
   let str: gapi.drive.realtime.CollaborativeString;
 
   before((done) => {
-    loadGapi().then(() => {
+    loadGapi(true).then(() => {
       initializeGapi(DEFAULT_CLIENT_ID).then(done);
     });
   });

--- a/test/src/undoablelist.spec.ts
+++ b/test/src/undoablelist.spec.ts
@@ -26,7 +26,7 @@ describe('GoogleUndoableList', () => {
   let glist: gapi.drive.realtime.CollaborativeList<JSONObject>;
 
   before((done) => {
-    loadGapi().then(() => {
+    loadGapi(true).then(() => {
       initializeGapi(DEFAULT_CLIENT_ID).then(done);
     });
   });

--- a/test/src/util.ts
+++ b/test/src/util.ts
@@ -2,12 +2,16 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  IModelDB, uuid
+  uuid
 } from '@jupyterlab/coreutils';
 
 import {
   TextModelFactory, DocumentRegistry, Context
 } from '@jupyterlab/docregistry';
+
+import {
+  IModelDB
+} from '@jupyterlab/observables';
 
 import {
   IRenderMime, RenderMime, RenderedHTML, defaultRendererFactories


### PR DESCRIPTION
This deprecates the realtime capabilities of the plugin (cf. #108 ). Existing realtime applications will continue to work until December 2018, which includes the default client application that is enabled for `localhost`. Hopefully we will have an alternative up and running by then.