### PR TITLE
Change name of extension file in docs

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -58,11 +58,11 @@ until the core of JupyterLab itself supports it.
 ### Seeding JupyterLab images with Google credentials
 While adding credentials via the settings functionality from within JupyterLab is possible, as described above, users may also wish to pre-seed these settings so the extension works out-of-the-box on start-up.
 
-The location of the `@jupyterlab/google-drive` plugin's settings can be found in `$SETTINGS_PATH/@jupyterlab/google-drive/drive.json`, where `$SETTINGS_PATH` can be found by entering `jupyter lab path` on your terminal from a running JupyterLab.
+The location of the `@jupyterlab/google-drive` plugin's settings can be found in `$SETTINGS_PATH/@jupyterlab/google-drive/drive.jupyterlab-settings`, where `$SETTINGS_PATH` can be found by entering `jupyter lab path` on your terminal from a running JupyterLab.
 
 For instance, the docker-stacks [base-notebook](https://github.com/jupyter/docker-stacks/blob/master/base-notebook/Dockerfile) comes pre-loaded with JupyterLab and if you were to add the google-drive extension, then given that the default user in that set-up is `jovyan`, the relevant path for the settings file would therefore be:
 
-`home/jovyan/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.json`
+`home/jovyan/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.jupyterlab-settings`
 
 As such, any file containing the credentials of the form `{ "clientId": "0123456789012-abcd2efghijklmnopqr2s9t2u6v4wxyz.apps.googleusercontent.com"}` (sample only) will need to get persisted to this location ahead of time.
 
@@ -70,12 +70,12 @@ There are many ways to do this.  A few to consider are:
 
 (i) adding the file as part of a docker image-build process
 
-One might include a `drive.json` file within a folder accessible to a Dockerfile used to build an image to be used to spawn JupyterLab.  For example, one could extend the docker-stacks base-notebook by adding the google-drive extension and pre-seed the credentials as follows:
+One might include a `drive.jupyterlab-settings` file within a folder accessible to a Dockerfile used to build an image to be used to spawn JupyterLab.  For example, one could extend the docker-stacks base-notebook by adding the google-drive extension and pre-seed the credentials as follows:
 
 ```
 FROM jupyter/base-notebook
 RUN jupyter labextension install @jupyterlab/google-drive
-COPY drive.json /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.json
+COPY drive.jupyterlab-settings /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.jupyterlab-settings
 ```
 
 (ii) injecting the credentials as part of an image-spawn process
@@ -97,5 +97,5 @@ singleuser
   lifecycleHooks:
     postStart:
       exec:
-        command: ["/bin/sh", "-c", "echo '{\"clientId\":\"${GOOGLE_DRIVE_CLIENT_ID}\"}' > /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.json"]
+        command: ["/bin/sh", "-c", "echo '{\"clientId\":\"${GOOGLE_DRIVE_CLIENT_ID}\"}' > /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.jupyterlab-settings"]
 ```


### PR DESCRIPTION
It appears (at least to me!) that the name of the extension setting file has changed in jlab 0.30 from `xxx.json` to `xxx.jupyterlab-settings`