### PR TITLE
Depaginate API requests.

### DIFF
--- a/src/drive/drive.ts
+++ b/src/drive/drive.ts
@@ -26,14 +26,37 @@ import {
 } from '../gapi';
 
 
+/**
+ * Fields to request for File resources.
+ */
 const RESOURCE_FIELDS = 'kind,id,name,mimeType,trashed,headRevisionId,' +
                         'parents,modifiedTime,createdTime,capabilities,' +
                         'webContentLink,teamDriveId';
 
+/**
+ * Fields to request for Team Drive resources.
+ */
 const TEAMDRIVE_FIELDS = 'kind,id,name,capabilities';
 
-const TEAMDRIVE_PAGE_SIZE = 100;
+/**
+ * Fields to request for File listings.
+ */
+const FILE_LIST_FIELDS = 'nextPageToken';
+
+/**
+ * Fields to reuest for Team Drive listings.
+ */
+const TEAMDRIVE_LIST_FIELDS = 'nextPageToken';
+
+/**
+ * Page size for file listing (max allowable).
+ */
 const FILE_PAGE_SIZE = 1000;
+
+/**
+ * Page size for team drive listing (max allowable).
+ */
+const TEAMDRIVE_PAGE_SIZE = 100;
 
 export
 const RT_MIMETYPE = 'application/vnd.google-apps.drive-sdk';
@@ -601,7 +624,7 @@ function searchDirectory(path: string, query: string = ''): Promise<FileResource
             q: fullQuery,
             pageSize: FILE_PAGE_SIZE,
             pageToken,
-            fields: 'files(' + RESOURCE_FIELDS + ')',
+            fields: `${FILE_LIST_FIELDS}, files(${RESOURCE_FIELDS})`,
             corpora: 'teamDrive',
             includeTeamDriveItems: true,
             supportsTeamDrives: true,
@@ -615,7 +638,7 @@ function searchDirectory(path: string, query: string = ''): Promise<FileResource
             q: fullQuery,
             pageSize: FILE_PAGE_SIZE,
             pageToken,
-            fields: 'files(' + RESOURCE_FIELDS + ')',
+            fields: `${FILE_LIST_FIELDS}, files(${RESOURCE_FIELDS})`,
             corpora: 'teamDrive',
             includeTeamDriveItems: true,
             supportsTeamDrives: true,
@@ -629,7 +652,7 @@ function searchDirectory(path: string, query: string = ''): Promise<FileResource
             q: fullQuery,
             pageSize: FILE_PAGE_SIZE,
             pageToken,
-            fields: 'files(' + RESOURCE_FIELDS + ')'
+            fields: `${FILE_LIST_FIELDS}, files(${RESOURCE_FIELDS})`
           });
         };
       }
@@ -1039,7 +1062,8 @@ function getResourceForRelativePath(pathComponent: string, folderId: string, tea
       createRequest = () => {
         return gapi.client.drive.files.list({
           q: query,
-          fields: 'files(' + RESOURCE_FIELDS + ')',
+          pageSize: FILE_PAGE_SIZE,
+          fields: `${FILE_LIST_FIELDS}, files(${RESOURCE_FIELDS})`,
           supportsTeamDrives: true,
           includeTeamDriveItems: true,
           corpora: 'teamDrive',
@@ -1050,7 +1074,8 @@ function getResourceForRelativePath(pathComponent: string, folderId: string, tea
       createRequest = () => {
         return gapi.client.drive.files.list({
           q: query,
-          fields: 'files(' + RESOURCE_FIELDS + ')'
+          pageSize: FILE_PAGE_SIZE,
+          fields: `${FILE_LIST_FIELDS}, files(${RESOURCE_FIELDS})`
         });
       };
     }
@@ -1130,7 +1155,7 @@ function listTeamDrives(): Promise<TeamDriveResource[]> {
     const getPage = (pageToken: string): Promise<gapi.client.drive.TeamDriveList> => {
       const createRequest = () => {
         return gapi.client.drive.teamdrives.list({
-          fields: 'teamDrives(' + TEAMDRIVE_FIELDS + ')',
+          fields: `${TEAMDRIVE_LIST_FIELDS}, teamDrives(${TEAMDRIVE_FIELDS})`,
           pageSize: TEAMDRIVE_PAGE_SIZE,
           pageToken
         });

--- a/src/drive/drive.ts
+++ b/src/drive/drive.ts
@@ -32,6 +32,9 @@ const RESOURCE_FIELDS = 'kind,id,name,mimeType,trashed,headRevisionId,' +
 
 const TEAMDRIVE_FIELDS = 'kind,id,name,capabilities';
 
+const TEAMDRIVE_PAGE_SIZE = 100;
+const FILE_PAGE_SIZE = 1000;
+
 export
 const RT_MIMETYPE = 'application/vnd.google-apps.drive-sdk';
 export
@@ -59,6 +62,11 @@ type RevisionResource = gapi.client.drive.Revision;
  */
 export
 type TeamDriveResource = gapi.client.drive.TeamDrive;
+
+/**
+ * An API response which may be paginated.
+ */
+type PaginatedResponse = gapi.client.drive.FileList | gapi.client.drive.TeamDriveList;
 
 /**
  * Alias for directory IFileType.
@@ -584,43 +592,50 @@ function searchDirectory(path: string, query: string = ''): Promise<FileResource
                             'and trashed = false';
     if (query) { fullQuery += ' and ' + query; }
 
-    let createRequest: () => gapi.client.HttpRequest<gapi.client.drive.FileList>;
-    if (resource.teamDriveId) {
-      // Case of a directory in a team drive.
-      createRequest = () => {
-        return gapi.client.drive.files.list({
-          q: fullQuery,
-          fields: 'files(' + RESOURCE_FIELDS + ')',
-          corpora: 'teamDrive',
-          includeTeamDriveItems: true,
-          supportsTeamDrives: true,
-          teamDriveId: resource.teamDriveId,
-        });
-      };
-    } else if (resource.kind === 'drive#teamDrive') {
-      // Case of the root of a team drive.
-      createRequest = () => {
-        return gapi.client.drive.files.list({
-          q: fullQuery,
-          fields: 'files(' + RESOURCE_FIELDS + ')',
-          corpora: 'teamDrive',
-          includeTeamDriveItems: true,
-          supportsTeamDrives: true,
-          teamDriveId: resource.id!,
-        });
-      };
-    } else {
-      // Case of the user directory.
-      createRequest = () => {
-        return gapi.client.drive.files.list({
-          q: fullQuery,
-          fields: 'files(' + RESOURCE_FIELDS + ')'
-        });
-      };
-    }
-    return driveApiRequest(createRequest);
-  }).then((result: gapi.client.drive.FileList) => {
-    return result.files || [];
+    const getPage = (pageToken?: string) => {
+      let createRequest: () => gapi.client.HttpRequest<gapi.client.drive.FileList>;
+      if (resource.teamDriveId) {
+        // Case of a directory in a team drive.
+        createRequest = () => {
+          return gapi.client.drive.files.list({
+            q: fullQuery,
+            pageSize: FILE_PAGE_SIZE,
+            pageToken,
+            fields: 'files(' + RESOURCE_FIELDS + ')',
+            corpora: 'teamDrive',
+            includeTeamDriveItems: true,
+            supportsTeamDrives: true,
+            teamDriveId: resource.teamDriveId,
+          });
+        };
+      } else if (resource.kind === 'drive#teamDrive') {
+        // Case of the root of a team drive.
+        createRequest = () => {
+          return gapi.client.drive.files.list({
+            q: fullQuery,
+            pageSize: FILE_PAGE_SIZE,
+            pageToken,
+            fields: 'files(' + RESOURCE_FIELDS + ')',
+            corpora: 'teamDrive',
+            includeTeamDriveItems: true,
+            supportsTeamDrives: true,
+            teamDriveId: resource.id!,
+          });
+        };
+      } else {
+        // Case of the user directory.
+        createRequest = () => {
+          return gapi.client.drive.files.list({
+            q: fullQuery,
+            pageSize: FILE_PAGE_SIZE,
+            pageToken,
+            fields: 'files(' + RESOURCE_FIELDS + ')'
+          });
+        };
+      }
+      return driveApiRequest(createRequest);
+    };
+    return depaginate(getPage, 'files');
   });
 }
 
@@ -1112,15 +1127,17 @@ function driveForName(name: string): Promise<TeamDriveResource | FileResource> {
  */
 function listTeamDrives(): Promise<TeamDriveResource[]> {
   return gapiAuthorized.promise.then(() => {
-    const createRequest = () => {
-      return gapi.client.drive.teamdrives.list({
-        fields: 'teamDrives(' + TEAMDRIVE_FIELDS + ')'
-      });
+    const getPage = (pageToken: string): Promise<gapi.client.drive.TeamDriveList> => {
+      const createRequest = () => {
+        return gapi.client.drive.teamdrives.list({
+          fields: 'teamDrives(' + TEAMDRIVE_FIELDS + ')',
+          pageSize: TEAMDRIVE_PAGE_SIZE,
+          pageToken
+        });
+      };
+      return driveApiRequest<gapi.client.drive.TeamDriveList>(createRequest);
     };
-    return driveApiRequest<gapi.client.drive.TeamDriveList>(createRequest)
-    .then(result => {
-      return result.teamDrives || [];
-    });
+    return depaginate(getPage, 'teamDrives');
   });
 }
 
@@ -1147,6 +1164,22 @@ export
 function isDirectory(resource: FileResource): boolean {
   return !!(resource.kind === 'drive#teamDrive' ||
             resource.mimeType === FOLDER_MIMETYPE);
+}
+
+/**
+ * Depaginate a series of requests into a single array.
+ */
+function depaginate<T extends FileResource | TeamDriveResource, L extends PaginatedResponse>(getPage: (pageToken?: string) => Promise<L>, listName: keyof L, pageToken?: string): Promise<T[]> {
+  return getPage(pageToken).then(list => {
+    const total = list[listName];
+    if (list.nextPageToken) {
+      return depaginate<T, L>(getPage, listName, list.nextPageToken).then(next => {
+        return [...total, ...next];
+      });
+    } else {
+      return total;
+    }
+  });
 }
 
 /**

--- a/src/drive/drive.ts
+++ b/src/drive/drive.ts
@@ -683,15 +683,18 @@ function searchSharedFiles(query: string = ''): Promise<FileResource[]> {
     let fullQuery = 'sharedWithMe = true';
     if (query) { fullQuery += ' and ' + query; }
 
-    const createRequest = () => {
-      return gapi.client.drive.files.list({
-        q: fullQuery,
-        fields: 'files(' + RESOURCE_FIELDS + ')'
-      });
+    const getPage = (pageToken?: string) => {
+      const createRequest = () => {
+        return gapi.client.drive.files.list({
+          q: fullQuery,
+          pageSize: FILE_PAGE_SIZE,
+          pageToken,
+          fields: `${FILE_LIST_FIELDS}, files(${RESOURCE_FIELDS})`
+        });
+      };
+      return driveApiRequest(createRequest);
     };
-    return driveApiRequest(createRequest);
-  }).then((result: gapi.client.drive.FileList) => {
-    return result.files || [];
+    return depaginate(getPage, 'files');
   });
 }
 


### PR DESCRIPTION
Depaginates long listings from the Google Drive API. This includes file listings, team drive listings, and revision listings. Fixes #116 