### PR TITLE
Update setup.md

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -102,5 +102,5 @@ singleuser
   lifecycleHooks:
     postStart:
       exec:
-        command: ["/bin/sh", "-c", "echo '{\"clientId\":\"${GOOGLE_DRIVE_CLIENT_ID}\"}' > /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.jupyterlab-settings"]
+        command: ["/bin/sh", "-c", "mkdir -p /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/google-drive; echo '{\"clientId\":\"${GOOGLE_DRIVE_CLIENT_ID}\"}' > /home/jovyan/.jupyter/lab/user-settings/@jupyterlab/google-drive/drive.jupyterlab-settings"]
 ```


### PR DESCRIPTION
1. The directory doesn't exist and therefore the `echo` call fails

Additional considerations for possible changes: 
2. Also, for me the use of `GOOGLE_DRIVE_CLIENT_ID` variable didn't work, it gets printed just as a string. We had to use the value of the client id directly.
3. /home/jovyan is loaded from persisted volume in the general ztjh and docker-stacks - so putting the settings file in the docker image doesn't work as the directory gets overwritten